### PR TITLE
Update `Multidict` to version `5.2.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "multidict" %}
-{% set version = "5.1.0" %}
-{% set sha256 = "25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5" %}
+{% set version = "5.2.0" %}
+{% set sha256 = "0dd1c93edb444b33ba2274b66f63def8a327d607c6c790772f448a53b6ea59ce" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  skip: true  # [py2k]
+  skip: true  # [py<36]
 
 requirements:
   build:
@@ -23,6 +23,8 @@ requirements:
     - cython
     - python
     - pip
+    - setuptools >=40
+    - wheel
   run:
     - python
 
@@ -36,7 +38,7 @@ test:
 
 about:
   home: http://github.com/aio-libs/multidict
-  license: Apache 2.0
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: 'multidict implementation'


### PR DESCRIPTION
  `multidict` version `5.2.0`
1. check the upstream
    https://github.com/aio-libs/multidict/tree/v5.2.0

2. check the pinnings
     https://github.com/aio-libs/multidict/blob/v5.2.0/setup.py
    https://github.com/aio-libs/multidict/blob/v5.2.0/setup.cfg
    https://github.com/aio-libs/multidict/blob/v5.2.0/pyproject.toml

3. check the changelogs
    https://github.com/aio-libs/multidict/tree/v5.2.0/CHANGES

4. additional research
    https://github.com/conda-forge/multidict-feedstock/issues

currently there are no open issues mentioned in conda-forge

5. verify dev_url
    http://github.com/aio-libs/multidict

6. verify doc_url
    http://multidict.readthedocs.io/

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `multidict` package version `5.2.0` the folowing
command was used:
`conda build multidict-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `multidict` to version `5.2.0`
