### PR TITLE
Rebuild multidict 5.2.0 for python 3.10 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 3
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: true  # [py<36]
 
 requirements:
@@ -37,16 +37,17 @@ test:
     - py.test tests
 
 about:
-  home: http://github.com/aio-libs/multidict
+  home: https://github.com/aio-libs/multidict
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: 'multidict implementation'
+  license_url: https://github.com/aio-libs/multidict/blob/master/LICENSE
+  summary: The multidict implementation
 
   description: |
     Multidicts are useful for working with HTTP headers, URL query args etc.
-  doc_url: http://multidict.readthedocs.io/
-  dev_url: http://github.com/aio-libs/multidict
+  doc_url: https://multidict.readthedocs.io/
+  dev_url: https://github.com/aio-libs/multidict
   doc_source_url: https://github.com/aio-libs/multidict/tree/master/docs
 
 extra:


### PR DESCRIPTION
To address the issue https://github.com/ContinuumIO/anaconda-issues/issues/13020

Actions:
1. Bump build number to 3 for consistency because now we have 0 and 2 for different python versions
2. Add `license_url`
3. Fix urls